### PR TITLE
New zone optimizations

### DIFF
--- a/App.config
+++ b/App.config
@@ -42,6 +42,8 @@
     <add key="MapColor[3]" value="#ACACAC" />
     <add key="MapColor[4]" value="#DCDCDC" />
     <add key="ClientSettingsProvider.ServiceUri" value="" />
+    <add key="MinArrowDistance" value="25" />
+    <add key="AvgArrowLength" value="75" />
   </appSettings>
   <system.web>
     <membership defaultProvider="ClientAuthenticationMembershipProvider">

--- a/D2RAssist.csproj
+++ b/D2RAssist.csproj
@@ -38,6 +38,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -47,6 +48,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|x64'">
     <DebugSymbols>true</DebugSymbols>
@@ -57,6 +59,7 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>
@@ -67,6 +70,7 @@
     <LangVersion>7.3</LangVersion>
     <ErrorReport>prompt</ErrorReport>
     <Prefer32Bit>true</Prefer32Bit>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup>
     <ManifestCertificateThumbprint>3DB9B26A33D3BC5805AF01B7BC6B71FE986ABD87</ManifestCertificateThumbprint>
@@ -143,16 +147,16 @@
       <DependentUpon>Overlay.cs</DependentUpon>
     </EmbeddedResource>
     <None Include="D2MapApi\Run.bat">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <Content Include="D2MapApi\d2mapapi.exe">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="D2MapApi\fmt.dll">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="D2MapApi\README.txt">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <None Include="Resources\Icon1.ico" />
     <None Include="Resources\Icon2.ico" />

--- a/Helpers/MapRenderer.cs
+++ b/Helpers/MapRenderer.cs
@@ -95,7 +95,7 @@ namespace D2RAssist.Helpers
                     for (int y = 0; y < mapData.mapRows[x].Length; y++)
                     {
                         int type = mapData.mapRows[x][y];
-                        Color? typeColor = Settings.Map.Colors.LookupMapColor(type);
+                        Color? typeColor = Settings.Map.Colors.MapColors[type];
                         if (typeColor != null)
                         {
                             uncroppedBackground.SetPixel(y, x, (Color)typeColor);

--- a/Overlay.cs
+++ b/Overlay.cs
@@ -45,6 +45,7 @@ namespace D2RAssist
 
         public Overlay()
         {
+            Settings.Map.Colors.InitMapColors();
             InitializeComponent();
         }
 

--- a/Types/Settings.cs
+++ b/Types/Settings.cs
@@ -83,6 +83,8 @@ namespace D2RAssist.Types
             public static bool DrawExitArrow = Convert.ToBoolean(ConfigurationManager.AppSettings["DrawExitArrow"]);
             public static bool DrawQuestArrow = Convert.ToBoolean(ConfigurationManager.AppSettings["DrawQuestArrow"]);
             public static bool DrawWaypointArrow = Convert.ToBoolean(ConfigurationManager.AppSettings["DrawWaypointArrow"]);
+            public static int MinArrowDistance = Convert.ToInt16(ConfigurationManager.AppSettings["MinArrowDistance"]);
+            public static int AvgArrowLength = Convert.ToInt32(ConfigurationManager.AppSettings["AvgArrowLength"]);
         }
 
         public static class Api

--- a/Types/Settings.cs
+++ b/Types/Settings.cs
@@ -49,6 +49,14 @@ namespace D2RAssist.Types
                 public static readonly Color ArrowWaypoint = ColorTranslator.FromHtml(ConfigurationManager.AppSettings["ArrowWaypoint"]);
                 public static readonly Color LabelColor = ColorTranslator.FromHtml(ConfigurationManager.AppSettings["LabelColor"]);
 
+                public static void InitMapColors()
+                {
+                    for (var i = -1; i < 600; i++)//not sure what the max is here...
+                    {
+                        LookupMapColor(i);
+                    }
+                }
+
                 public static Color? LookupMapColor(int type)
                 {
                     string key = "MapColor[" + type + "]";


### PR DESCRIPTION
Added a couple optimizations when switching zones:
* Changed settings to look up map colors on startup. ~80ms off new zone load times
* Changed image cropping to use unsafe to speed up image cropping by a lot, ~150-200+ms off new zone load times, depending on map size
This brings load times from ~500ms down to ~200ms.